### PR TITLE
Feature/alternate urls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ikeikeikeike/go-sitemap-generator/v2
+module github.com/kf99916/go-sitemap-generator/v2
 
 go 1.9
 

--- a/stm/builder_indexfile.go
+++ b/stm/builder_indexfile.go
@@ -28,8 +28,8 @@ func (b *BuilderIndexfile) Add(link interface{}) BuilderError {
 
 	alternativeURLs := bldr.loc.AlternativeURLs()
 	for _, alternativeURL := range alternativeURLs {
-		s := NewSitemapIndexURL(b.opts, URL{"loc": alternativeURL})
-		b.content = append(b.content, s.XML()...)
+		smu := NewSitemapIndexURL(b.opts, URL{{"loc", alternativeURL}})
+		b.content = append(b.content, smu.XML()...)
 		b.linkcnt++
 	}
 

--- a/stm/builder_indexfile.go
+++ b/stm/builder_indexfile.go
@@ -23,9 +23,16 @@ func (b *BuilderIndexfile) Add(link interface{}) BuilderError {
 
 	smu := NewSitemapIndexURL(b.opts, URL{"loc": bldr.loc.URL()})
 	b.content = append(b.content, smu.XML()...)
-
 	b.totalcnt += bldr.linkcnt
 	b.linkcnt++
+
+	alternativeURLs := bldr.loc.AlternativeURLs()
+	for _, alternativeURL := range alternativeURLs {
+		s := NewSitemapIndexURL(b.opts, URL{"loc": alternativeURL})
+		b.content = append(b.content, s.XML()...)
+		b.linkcnt++
+	}
+
 	return nil
 }
 

--- a/stm/builder_url.go
+++ b/stm/builder_url.go
@@ -39,6 +39,12 @@ var fieldnames = ToLowerString(structs.Names(&URLModel{}))
 func NewSitemapURL(opts *Options, url URL) (SitemapURL, error) {
 	smu := &sitemapURL{opts: opts, data: url}
 	err := smu.validate()
+	for _, value := range smu.data {
+		key := value[0].(string)
+		if key == "alternates" {
+			smu.data = append(smu.data, []interface{}{"xhtml:link", value[1]})
+		}
+	}
 	return smu, err
 }
 
@@ -109,6 +115,8 @@ func (su *sitemapURL) XML() []byte {
 		priority := url.CreateElement("priority")
 		priority.SetText("0.5")
 	}
+
+	SetBuilderElementValue(url, su.data, "xhtml:link")
 	SetBuilderElementValue(url, su.data, "expires")
 	SetBuilderElementValue(url, su.data, "mobile")
 	SetBuilderElementValue(url, su.data, "news")

--- a/stm/location.go
+++ b/stm/location.go
@@ -67,6 +67,26 @@ func (loc *Location) URL() string {
 	return base.String()
 }
 
+// AlternativeURLs returns path to combine AlternativeSitemapsHost, sitemapsPath and
+// Filename on website with it uses ResolveReference.
+func (loc *Location) AlternativeURLs() []string {
+	alternativeSitemapsHosts := loc.opts.AlternativeSitemapsHosts()
+	alternativeURLs := []string{}
+	for _, alternativeSitemapsHost := range alternativeSitemapsHosts {
+		u, _ := url.Parse(alternativeSitemapsHost)
+
+		for _, ref := range []string{
+			loc.opts.sitemapsPath + "/", loc.Filename(),
+		} {
+			u, _ = u.Parse(ref)
+		}
+
+		alternativeURLs = append(alternativeURLs, u.String())
+	}
+
+	return alternativeURLs
+}
+
 // Filesize returns file size this struct has.
 func (loc *Location) Filesize() int64 {
 	f, _ := os.Open(loc.Path())

--- a/stm/options.go
+++ b/stm/options.go
@@ -4,31 +4,33 @@ package stm
 func NewOptions() *Options {
 	// Default values
 	return &Options{
-		defaultHost:  "http://www.example.com",
-		sitemapsHost: "", // http://s3.amazonaws.com/sitemap-generator/,
-		publicPath:   "public/",
-		sitemapsPath: "sitemaps/",
-		filename:     "sitemap",
-		verbose:      true,
-		compress:     true,
-		pretty:       false,
-		adp:          NewFileAdapter(),
+		defaultHost:              "http://www.example.com",
+		sitemapsHost:             "", // http://s3.amazonaws.com/sitemap-generator/,
+		alternativeSitemapsHosts: []string{},
+		publicPath:               "public/",
+		sitemapsPath:             "sitemaps",
+		filename:                 "sitemap",
+		verbose:                  true,
+		compress:                 true,
+		pretty:                   false,
+		adp:                      NewFileAdapter(),
 	}
 }
 
 // Options exists for the Sitemap struct.
 type Options struct {
-	defaultHost  string
-	sitemapsHost string
-	publicPath   string
-	sitemapsPath string
-	filename     string
-	verbose      bool
-	compress     bool
-	pretty       bool
-	adp          Adapter
-	nmr          *Namer
-	loc          *Location
+	defaultHost              string
+	sitemapsHost             string
+	alternativeSitemapsHosts []string
+	publicPath               string
+	sitemapsPath             string
+	filename                 string
+	verbose                  bool
+	compress                 bool
+	pretty                   bool
+	adp                      Adapter
+	nmr                      *Namer
+	loc                      *Location
 }
 
 // SetDefaultHost sets that arg from Sitemap.Finalize method
@@ -39,6 +41,11 @@ func (opts *Options) SetDefaultHost(host string) {
 // SetSitemapsHost sets that arg from Sitemap.SetSitemapsHost method
 func (opts *Options) SetSitemapsHost(host string) {
 	opts.sitemapsHost = host
+}
+
+// AddAlternativeSitemapsHosts adds that arg from Sitemap.AddAlternativeSitemapsHosts method
+func (opts *Options) AddAlternativeSitemapsHost(host string) {
+	opts.alternativeSitemapsHosts = append(opts.alternativeSitemapsHosts, host)
 }
 
 // SetSitemapsPath sets that arg from Sitemap.SetSitemapsPath method.
@@ -82,6 +89,11 @@ func (opts *Options) SitemapsHost() string {
 		return opts.sitemapsHost
 	}
 	return opts.defaultHost
+}
+
+// AlternativeSitemapsHosts sets that arg from Sitemap.AlternativeSitemapsHosts method
+func (opts *Options) AlternativeSitemapsHosts() []string {
+	return opts.alternativeSitemapsHosts
 }
 
 // Location returns the Location's pointer with

--- a/stm/ping.go
+++ b/stm/ping.go
@@ -12,27 +12,34 @@ func PingSearchEngines(opts *Options, urls ...string) {
 		"http://www.google.com/webmasters/tools/ping?sitemap=%s",
 		"http://www.bing.com/webmaster/ping.aspx?siteMap=%s",
 	}...)
-	sitemapURL := opts.IndexLocation().URL()
+
+	indexLocation := opts.IndexLocation()
+	sitemapURLs := []string{indexLocation.URL()}
+	for _, alternativeURL := range indexLocation.AlternativeURLs() {
+		sitemapURLs = append(sitemapURLs, alternativeURL)
+	}
 
 	bufs := len(urls)
 	does := make(chan string, bufs)
 	client := http.Client{Timeout: time.Duration(5 * time.Second)}
 
 	for _, url := range urls {
-		go func(baseurl string) {
-			url := fmt.Sprintf(baseurl, sitemapURL)
-			println("Ping now:", url)
+		for _, sitemapURL := range sitemapURLs {
+			go func(baseurl string) {
+				url := fmt.Sprintf(baseurl, sitemapURL)
+				println("Ping now:", url)
 
-			resp, err := client.Get(url)
-			if err != nil {
-				does <- fmt.Sprintf("[E] Ping failed: %s (URL:%s)",
-					err, url)
-				return
-			}
-			defer resp.Body.Close()
+				resp, err := client.Get(url)
+				if err != nil {
+					does <- fmt.Sprintf("[E] Ping failed: %s (URL:%s)",
+						err, url)
+					return
+				}
+				defer resp.Body.Close()
 
-			does <- fmt.Sprintf("Successful ping of `%s`", url)
-		}(url)
+				does <- fmt.Sprintf("Successful ping of `%s`", url)
+			}(url)
+		}
 	}
 
 	for i := 0; i < bufs; i++ {

--- a/stm/ping.go
+++ b/stm/ping.go
@@ -25,7 +25,7 @@ func PingSearchEngines(opts *Options, urls ...string) {
 
 	for _, url := range urls {
 		for _, sitemapURL := range sitemapURLs {
-			go func(baseurl string) {
+			go func(baseurl, sitemapURL string) {
 				url := fmt.Sprintf(baseurl, sitemapURL)
 				println("Ping now:", url)
 
@@ -38,7 +38,7 @@ func PingSearchEngines(opts *Options, urls ...string) {
 				defer resp.Body.Close()
 
 				does <- fmt.Sprintf("Successful ping of `%s`", url)
-			}(url)
+			}(url, sitemapURL)
 		}
 	}
 

--- a/stm/sitemap.go
+++ b/stm/sitemap.go
@@ -34,6 +34,11 @@ func (sm *Sitemap) SetSitemapsHost(host string) {
 	sm.opts.SetSitemapsHost(host)
 }
 
+// AddAlternativeSitemapsHost is the alternative remote host where your sitemaps will be hosted
+func (sm *Sitemap) AddAlternativeSitemapsHost(host string) {
+	sm.opts.AddAlternativeSitemapsHost(host)
+}
+
 // SetSitemapsPath sets this to a directory/path if you don't
 // want to upload to the root of your `SitemapsHost`
 func (sm *Sitemap) SetSitemapsPath(path string) {


### PR DESCRIPTION
Empower the index sitemaps include multiple sitemap urls.

Like this:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
        <loc>https://en-us.abc.com/sitemap1.xml.gz</loc>
        <lastmod>2019-04-11T18:37:44+08:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://zh-tw.abc.com/sitemap1.xml.gz</loc>
        <lastmod>2019-04-11T18:37:44+08:00</lastmod>
    </sitemap>
</sitemapindex>
```